### PR TITLE
Protection for multi_speed VSP status frame

### DIFF
--- a/aqualogic/core.py
+++ b/aqualogic/core.py
@@ -219,7 +219,7 @@ class AquaLogic():
                 if self._pump_speed != value:
                     self._pump_speed = value
                     data_changed_callback(self)
-            elif frame_type == self.FRAME_TYPE_PUMP_STATUS:
+            elif (frame_type == self.FRAME_TYPE_PUMP_STATUS) & (len(frame) >= 5):
                 # Pump status messages sent out by Hayward VSP pumps
                 self._multi_speed_pump = True
                 speed = frame[2]


### PR DESCRIPTION
As it's implemented processing thread will always exit "out of index" for frame[2] when receinving the pump status frame type. In my setup there are such frame types once the VSP is running however there's no power of speed info as part of the frame.

I haven't finished finding a solution to work around the high and low pump state that seems to depend on the multi_speed flag.

I also noticed that there's a version 1.1 coming from pip install will this version merger back to git?

Cheers