### PR TITLE
display update: on prologic display flashing characters set bit 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Deprecated
+I recommend using [aqualogic package at rs485_frame-examples](https://github.com/b3nj1/rs485_frame-examples) insteaed
 # aqualogic
 A python library to interface with Hayward/Goldline AquaLogic/ProLogic pool controllers. Based on Goldline prototol decoding work done by draythomp (http://www.desert-home.com/p/swimming-pool.html). Used by the [Home Assistant AquaLogic component](https://www.home-assistant.io/components/aqualogic/).
 

--- a/aqualogic/core.py
+++ b/aqualogic/core.py
@@ -287,7 +287,6 @@ class AquaLogic():
                           # Flashing values are encoded with bit 8 set
                           display_frame.append(0x7f & v)
                       text = display_frame.decode('utf-8')
-                      _LOGGER.display(f"display: {text}: {frame}")
                     except UnicodeDecodeError as e:
                       _LOGGER.info(f"decerr: {frame}: {e}")
                       continue

--- a/aqualogic/core.py
+++ b/aqualogic/core.py
@@ -277,8 +277,14 @@ class AquaLogic():
                         self._pump_power = power
                         data_changed_callback(self)
                 elif frame_type == self.FRAME_TYPE_DISPLAY_UPDATE:
-                    # Convert LCD-specific degree symbol and decode to utf-8
-                    text = frame.replace(b'\xdf', b'\xc2\xb0').decode('utf-8')
+                    try:
+                      # Flashing values are encoded with bit 8 set
+                      ascii_frame = bytearray([x & 0x7f for x in frame])
+                      text = ascii_frame.decode('utf-8')
+                    except UnicodeDecodeError as e:
+                      _LOGGER.info(f"decerr: {frame}: {e}")
+                      continue
+
                     parts = text.split()
                     _LOGGER.debug('%3.3f: Display update: %s',
                                   frame_start_time, parts)

--- a/aqualogic/core.py
+++ b/aqualogic/core.py
@@ -278,9 +278,16 @@ class AquaLogic():
                         data_changed_callback(self)
                 elif frame_type == self.FRAME_TYPE_DISPLAY_UPDATE:
                     try:
-                      # Flashing values are encoded with bit 8 set
-                      ascii_frame = bytearray([x & 0x7f for x in frame])
-                      text = ascii_frame.decode('utf-8')
+                      display_frame = bytearray()
+                      for v in frame:
+                        if v == 0xdf or v == 0x5f:
+                          # Convert LCD-specific degree symbol and decode to utf-8
+                          display_frame.extend(b'\xc2\xb0')
+                        else:
+                          # Flashing values are encoded with bit 8 set
+                          display_frame.append(0x7f & v)
+                      text = display_frame.decode('utf-8')
+                      _LOGGER.display(f"display: {text}: {frame}")
                     except UnicodeDecodeError as e:
                       _LOGGER.info(f"decerr: {frame}: {e}")
                       continue


### PR DESCRIPTION
I don't know if this is universal to all controllers. On my system, I see that when a character is flashing on the display, 128 is added to the character code. This PR removes bit 8 from the display character.

If this is unique to some systems, how should that be differentiated in the code?

Thanks,
Benjamin