### PR TITLE
Fix serial write: use write() instead of send()

### DIFF
--- a/aqualogic/core.py
+++ b/aqualogic/core.py
@@ -126,7 +126,7 @@ class AquaLogic():
         self._socket.send(data)
     
     def _write_to_serial(self, data):
-        self._serial.send(data)
+        self._serial.write(data)
         self._serial.flush()
         
     def _write_to_io(self, data):

--- a/aqualogic/web.py
+++ b/aqualogic/web.py
@@ -15,7 +15,6 @@ _LOGGER = logging.getLogger(__name__)
 class WebServer():
     def __init__(self, panel):
         self._panel = panel
-        self._msg_queue = asyncio.Queue()
 
     def _run_thread(self):
         asyncio.set_event_loop(self._loop)
@@ -25,7 +24,8 @@ class WebServer():
             pass
 
     def start(self, port):
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.new_event_loop()
+        self._msg_queue = asyncio.Queue()
 
         # Set up the HTTP server
         app = web.Application()


### PR DESCRIPTION
pyserial's Serial object has write(), not send(). This caused an AttributeError when trying to send key events over the serial port.