### PR TITLE
Fix install on modern Python: deps, aiohttp import, web guard

### DIFF
--- a/aqualogic/core.py
+++ b/aqualogic/core.py
@@ -63,6 +63,7 @@ class AquaLogic():
         self._send_queue = queue.Queue()
         self._multi_speed_pump = False
         self._heater_auto_mode = True  # Assume the heater is in auto mode
+        self._web = None
 
         if web_port and web_port != 0:
             # Start the web server
@@ -283,7 +284,8 @@ class AquaLogic():
                     _LOGGER.debug('%3.3f: Display update: %s',
                                   frame_start_time, parts)
 
-                    self._web.text_updated(text)
+                    if self._web:
+                        self._web.text_updated(text)
 
                     try:
                         if parts[0] == 'Pool' and parts[1] == 'Temp':

--- a/aqualogic/web.py
+++ b/aqualogic/web.py
@@ -1,4 +1,4 @@
-from aiohttp import web, streamer
+from aiohttp import web
 import aiohttp
 import socketserver
 import socket

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,7 @@ setup(
   ],
   install_requires=[
     'pyserial',
-  ]  
+    'aiohttp',
+    'websockets',
+  ]
 )


### PR DESCRIPTION
Three small fixes so the library installs and runs on current Python and aiohttp versions. I hit these setting the library up fresh against a live AquaLogic P4 over an RS-485-to-Ethernet adapter.

### 1. Declare `aiohttp` and `websockets` (`setup.py`)
`web.py` has always imported both, but `install_requires` only listed `pyserial`, so a clean `pip install` leaves the package unimportable (`ModuleNotFoundError: No module named 'aiohttp'`).

### 2. Drop the unused `streamer` import (`web.py`)
`from aiohttp import web, streamer` — `streamer` was removed from aiohttp and now raises `ImportError` on import, which cascades through `core.py` and breaks the whole package. It isn't referenced anywhere, so this just removes it.

### 3. Guard the web-server callback (`core.py`)
When the web server is disabled (`web_port=0`), `self._web` was never assigned, so the first display-update frame raised `AttributeError: 'AquaLogic' object has no attribute '_web'`. Initialize `_web` to `None` and skip the call when the server isn't running. This also lets the unit tests run without standing up a web server.

### Testing
Verified end to end against a live AquaLogic P4 over an RS-485-to-Ethernet adapter — frames decode and pool temp / pump speed / power / states update correctly. Existing parsing logic is unchanged.